### PR TITLE
Add compatibility with ruby 1.8.7

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 maintainer       'Washington Botelho'
 maintainer_email 'wbotelhos@gmail.com'
 name             'chef-unicorn'
-version          '0.1.4'
+version          '0.1.5'
 
 recipe 'chef-unicorn::config',  'Installs configuration.'
 recipe 'chef-unicorn::service', 'Installs service file.'

--- a/templates/default/unicorn.rb.erb
+++ b/templates/default/unicorn.rb.erb
@@ -11,7 +11,7 @@ working_directory <%= @working_directory.inspect %>
 <% end -%>
 
 <% if @listen %>
-listen <%= @listen.inspect %> <%= @backlog ? ", backlog: #{@backlog}" : '' %>
+listen <%= @listen.inspect %> <%= @backlog ? ", :backlog => #{@backlog}" : '' %>
 <% end -%>
 
 <% if @timeout %>


### PR DESCRIPTION
Replaces 'modern' ruby hash syntax with old-school hash-rocket syntax for compatibility with old ruby.

As shown on https://github.com/defunkt/unicorn/blob/master/examples/unicorn.conf.rb