### PR TITLE
Add EnvironmentFile directive support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,15 @@ Installs and configure Unicorn server.
 
 ## Service
 
-|-------------------------------------------------------|---------------------|
 |Attribute                                              |Default              |
+|-------------------------------------------------------|---------------------|
 |default['chef-unicorn']['config']['after_fork']        |...                  |
 |default['chef-unicorn']['config']['before_fork']       |...                  |
 |default['chef-unicorn']['service']['bundle_gemfile']   |nil                  |
 |default['chef-unicorn']['service']['bundle']           |'/usr/bin/bundle'    |
 |default['chef-unicorn']['service']['config']           |nil                  |
 |default['chef-unicorn']['service']['environment']      |'production'         |
+|default['chef-unicorn']['service']['environment_file'] |''                   |
 |default['chef-unicorn']['service']['gem_home']         |'/usr/local/ruby/gem'|
 |default['chef-unicorn']['service']['locale']           |'en_US.UTF-8'        |
 |default['chef-unicorn']['service']['name']             |'unicorn'            |

--- a/attributes/service.rb
+++ b/attributes/service.rb
@@ -6,6 +6,7 @@ default['chef-unicorn']['service']['bundle_gemfile']    = nil
 default['chef-unicorn']['service']['bundle']            = '/usr/bin/bundle'
 default['chef-unicorn']['service']['config']            = nil
 default['chef-unicorn']['service']['environment']       = 'production'
+default['chef-unicorn']['service']['environment_file']  = ''
 default['chef-unicorn']['service']['gem_home']          = '/usr/local/ruby/gem'
 default['chef-unicorn']['service']['locale']            = 'en_US.UTF-8'
 default['chef-unicorn']['service']['name']              = 'unicorn'

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -17,6 +17,7 @@ template "/etc/systemd/system/#{service_name}.service" do
     bundle:            node['chef-unicorn']['service']['bundle'],
     config:            node['chef-unicorn']['service']['config'],
     environment:       node['chef-unicorn']['service']['environment'],
+    environment_file:  node['chef-unicorn']['service']['environment_file'],
     gem_home:          node['chef-unicorn']['service']['gem_home'],
     locale:            node['chef-unicorn']['service']['locale'],
     pidfile:           node['chef-unicorn']['service']['pidfile'],

--- a/templates/default/etc/systemd/system/service.erb
+++ b/templates/default/etc/systemd/system/service.erb
@@ -3,6 +3,7 @@ Description=Unicorn
 
 [Service]
 Environment=BUNDLE_GEMFILE=<%= @bundle_gemfile %> LANG=<%= @locale %> LC_ALL=<%= @locale %> LANGUAGE=<%= @locale %> <%= "GEM_HOME=#{@gem_home}" if @gem_home %>
+EnvironmentFile=-<%= @environment_file %>
 ExecReload=/bin/kill -SIGUSR2 $MAINPID
 ExecStart=<%= @bundle %> exec unicorn -E <%= @environment %> -c <%= @config %>
 PIDFile=<%= @pidfile %>


### PR DESCRIPTION
Changelog
- Add EnvironmentFile directive support
  - if env file does not exist, it will not be read and no error or warning message is logged
https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=
https://coreos.com/os/docs/latest/using-environment-variables-in-systemd-units.html#environmentfile-directive
- Fix readme formatting